### PR TITLE
Add `CopyCommand` and `CopyCommandParser`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import java.awt.HeadlessException;
 import java.awt.Toolkit;
 import java.awt.datatransfer.Clipboard;
 import java.awt.datatransfer.StringSelection;
@@ -27,6 +28,9 @@ public class CopyCommand extends Command {
 
     public static final String MESSAGE_COPY_SUCCESS = "Successfully copied information to clipboard!";
 
+    public static final String MESSAGE_NO_CLIPBOARD_FOUND = "Clipboard does not exist in your environment! "
+            + "Displaying information for you:\n\n";
+
     private final Index targetIndex;
 
     public CopyCommand(Index targetIndex) {
@@ -42,8 +46,12 @@ public class CopyCommand extends Command {
         }
         Person personToCopy = lastShownList.get(targetIndex.getZeroBased());
         String informationToCopy = getInformation(personToCopy);
-        copyToClipboard(informationToCopy);
-        return new CommandResult(MESSAGE_COPY_SUCCESS);
+        try {
+            copyToClipboard(informationToCopy);
+            return new CommandResult(MESSAGE_COPY_SUCCESS);
+        } catch (HeadlessException e) {
+            return new CommandResult(MESSAGE_NO_CLIPBOARD_FOUND + informationToCopy);
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -1,0 +1,67 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.StringSelection;
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Person;
+
+public class CopyCommand extends Command {
+    public static final String COMMAND_WORD = "copy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+        + ": Copies the information of the person identified by the index number used in the displayed person list.\n"
+        + "Parameters: INDEX (must be a positive integer)\n"
+        + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_COPY_SUCCESS = "Successfully copied information to clipboard!";
+
+    private final Index targetIndex;
+
+    public CopyCommand(Index targetIndex) {
+        requireNonNull(targetIndex);
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Person> lastShownList = model.getFilteredPersonList();
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person personToCopy = lastShownList.get(targetIndex.getZeroBased());
+        String informationToCopy = getInformation(personToCopy);
+        copyToClipboard(informationToCopy);
+        return new CommandResult(MESSAGE_COPY_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+            || (other instanceof CopyCommand // instanceof handles nulls
+            && targetIndex.equals(((CopyCommand) other).targetIndex)); // state check
+    }
+
+    public String getInformation(Person personToCopy) {
+        String information = "";
+        information += String.format("Name: %s\n", personToCopy.getName());
+        information += String.format("Phone: %s\n", personToCopy.getPhone());
+        information += String.format("Email: %s\n", personToCopy.getEmail());
+        information += String.format("Address: %s\n", personToCopy.getAddress());
+        return information;
+    }
+
+    public void copyToClipboard(String information) {
+        StringSelection stringSelection = new StringSelection(information);
+        Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+        clipboard.setContents(stringSelection, null);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -13,6 +13,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
+/**
+ * Copies information to the user's clipboard, of a person identified using it's displayed index from the address book.
+ */
 public class CopyCommand extends Command {
     public static final String COMMAND_WORD = "copy";
 
@@ -26,7 +29,6 @@ public class CopyCommand extends Command {
     private final Index targetIndex;
 
     public CopyCommand(Index targetIndex) {
-        requireNonNull(targetIndex);
         this.targetIndex = targetIndex;
     }
 
@@ -59,6 +61,11 @@ public class CopyCommand extends Command {
         return information;
     }
 
+    /**
+     * Copies the information to user's clipboard
+     *
+     * @param information information to copy
+     */
     public void copyToClipboard(String information) {
         StringSelection stringSelection = new StringSelection(information);
         Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -20,7 +20,8 @@ public class CopyCommand extends Command {
     public static final String COMMAND_WORD = "copy";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Copies the information of the person identified by the index number used in the displayed person list.\n"
+            + ": Copies the information of the person identified by "
+            + "the index number used in the displayed person list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";
 

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -53,12 +53,12 @@ public class CopyCommand extends Command {
     }
 
     public String getInformation(Person personToCopy) {
-        String information = "";
-        information += String.format("Name: %s\n", personToCopy.getName());
-        information += String.format("Phone: %s\n", personToCopy.getPhone());
-        information += String.format("Email: %s\n", personToCopy.getEmail());
-        information += String.format("Address: %s\n", personToCopy.getAddress());
-        return information;
+        final StringBuilder infoBuilder = new StringBuilder();
+        infoBuilder.append("Name: " + personToCopy.getName() + "\n")
+            .append("Phone: " + personToCopy.getPhone() + "\n")
+            .append("Email: " + personToCopy.getEmail() + "\n")
+            .append("Address: " + personToCopy.getAddress() + "\n");
+        return infoBuilder.toString();
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/CopyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CopyCommand.java
@@ -14,15 +14,15 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Person;
 
 /**
- * Copies information to the user's clipboard, of a person identified using it's displayed index from the address book.
+ * Copies the details of an existing person in the address book to the user's clipboard.
  */
 public class CopyCommand extends Command {
     public static final String COMMAND_WORD = "copy";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-        + ": Copies the information of the person identified by the index number used in the displayed person list.\n"
-        + "Parameters: INDEX (must be a positive integer)\n"
-        + "Example: " + COMMAND_WORD + " 1";
+            + ": Copies the information of the person identified by the index number used in the displayed person list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_COPY_SUCCESS = "Successfully copied information to clipboard!";
 
@@ -48,16 +48,16 @@ public class CopyCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-            || (other instanceof CopyCommand // instanceof handles nulls
-            && targetIndex.equals(((CopyCommand) other).targetIndex)); // state check
+                || (other instanceof CopyCommand // instanceof handles nulls
+                && targetIndex.equals(((CopyCommand) other).targetIndex)); // state check
     }
 
     public String getInformation(Person personToCopy) {
         final StringBuilder infoBuilder = new StringBuilder();
         infoBuilder.append("Name: " + personToCopy.getName() + "\n")
-            .append("Phone: " + personToCopy.getPhone() + "\n")
-            .append("Email: " + personToCopy.getEmail() + "\n")
-            .append("Address: " + personToCopy.getAddress() + "\n");
+                .append("Phone: " + personToCopy.getPhone() + "\n")
+                .append("Email: " + personToCopy.getEmail() + "\n")
+                .append("Address: " + personToCopy.getAddress() + "\n");
         return infoBuilder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -9,6 +9,7 @@ import java.util.regex.Pattern;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
@@ -43,7 +44,6 @@ public class AddressBookParser {
         final String commandWord = matcher.group("commandWord");
         final String arguments = matcher.group("arguments");
         switch (commandWord) {
-
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
 
@@ -67,6 +67,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case CopyCommand.COMMAND_WORD:
+            return new CopyCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -6,8 +6,17 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CopyCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+/**
+ * Parses input arguments and creates a new CopyCommand object
+ */
 public class CopyCommandParser implements Parser<CopyCommand> {
 
+    /**
+     * Parses the given {@code String} of arguments in the context of the CopyCommand
+     * and returns an CopyCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
     public CopyCommand parse(String args) throws ParseException {
         try {
             Index index = ParserUtil.parseIndex(args);

--- a/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CopyCommandParser.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CopyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class CopyCommandParser implements Parser<CopyCommand> {
+
+    public CopyCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new CopyCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -1,8 +1,11 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.awt.GraphicsEnvironment;
@@ -43,4 +46,27 @@ public class CopyCommandTest {
 
         assertCommandFailure(copyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
+
+    @Test
+    public void equals() {
+        CopyCommand copyFirstCommand = new CopyCommand(INDEX_FIRST_PERSON);
+        CopyCommand copySecondCommand = new CopyCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(copyFirstCommand.equals(copyFirstCommand));
+
+        // same values -> returns true
+        CopyCommand copyFirstCommandCopy = new CopyCommand(INDEX_FIRST_PERSON);
+        assertTrue(copyFirstCommand.equals(copyFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(copyFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(copyFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(copyFirstCommand.equals(copySecondCommand));
+    }
+
 }

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -22,18 +22,17 @@ public class CopyCommandTest {
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "false")
+    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "false")
     public void execute_copyValidIndexInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
         Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        String actualMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
         String expectedMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
 
         assertCommandSuccess(copyCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "false")
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "false")
     public void execute_copyValidIndexNotInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -6,8 +6,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+import org.junit.jupiter.api.condition.DisabledIf;
+import org.junit.jupiter.api.condition.EnabledIf;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -22,7 +22,7 @@ public class CopyCommandTest {
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
-    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "false")
+    @EnabledIf(value = "java.awt.GraphicsEnvironment.isHeadless")
     public void execute_copyValidIndexInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
         Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
@@ -32,7 +32,7 @@ public class CopyCommandTest {
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "false")
+    @DisabledIf(value = "java.awt.GraphicsEnvironment.isHeadless")
     public void execute_copyValidIndexNotInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -22,17 +22,18 @@ public class CopyCommandTest {
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
-    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "false")
     public void execute_copyValidIndexInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
         Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String actualMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
         String expectedMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
 
         assertCommandSuccess(copyCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
-    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "false")
     public void execute_copyValidIndexNotInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -6,12 +6,15 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
 
 public class CopyCommandTest {
 
@@ -19,7 +22,18 @@ public class CopyCommandTest {
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
-    public void execute_copyValidIndex_success() {
+    @EnabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    public void execute_copyValidIndexInHeadless_success() {
+        CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
+        Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        String expectedMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
+
+        assertCommandSuccess(copyCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    @DisabledIfSystemProperty(named = "java.awt.headless", matches = "true")
+    public void execute_copyValidIndexNotInHeadless_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 
         assertCommandSuccess(copyCommand, model, CopyCommand.MESSAGE_COPY_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -5,9 +5,9 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
+import java.awt.GraphicsEnvironment;
+
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.DisabledIf;
-import org.junit.jupiter.api.condition.EnabledIf;
 
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -22,21 +22,18 @@ public class CopyCommandTest {
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
 
     @Test
-    @EnabledIf(value = "java.awt.GraphicsEnvironment.isHeadless")
-    public void execute_copyValidIndexInHeadless_success() {
-        CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
-        Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
-        String expectedMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
+    public void execute_copyValidIndex_success() {
+        if (GraphicsEnvironment.isHeadless()) {
+            CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
+            Person personToCopy = expectedModel.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+            String expectedMessage = CopyCommand.MESSAGE_NO_CLIPBOARD_FOUND + copyCommand.getInformation(personToCopy);
 
-        assertCommandSuccess(copyCommand, model, expectedMessage, expectedModel);
-    }
+            assertCommandSuccess(copyCommand, model, expectedMessage, expectedModel);
+        } else {
+            CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 
-    @Test
-    @DisabledIf(value = "java.awt.GraphicsEnvironment.isHeadless")
-    public void execute_copyValidIndexNotInHeadless_success() {
-        CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
-
-        assertCommandSuccess(copyCommand, model, CopyCommand.MESSAGE_COPY_SUCCESS, expectedModel);
+            assertCommandSuccess(copyCommand, model, CopyCommand.MESSAGE_COPY_SUCCESS, expectedModel);
+        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.awt.Toolkit;
+import java.awt.datatransfer.Clipboard;
+import java.awt.datatransfer.DataFlavor;
+import java.awt.datatransfer.StringSelection;
+import java.awt.datatransfer.UnsupportedFlavorException;
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+
+public class CopyCommandTest {
+
+    private final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    private final StringSelection emptyString = new StringSelection("");
+
+    @BeforeEach
+    public void setUp() {
+        // Clear clipboard contents
+        clipboard.setContents(emptyString, null);
+    }
+
+    @Test
+    public void execute_copyValidIndex_success() throws IOException, UnsupportedFlavorException {
+        Person personToCopy = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
+
+        assertCommandSuccess(copyCommand, model, CopyCommand.MESSAGE_COPY_SUCCESS, expectedModel);
+
+        // Check contents of clipboard
+        try {
+            String expectedInformation = copyCommand.getInformation(personToCopy);
+            String actualInformation = (String) clipboard.getData(DataFlavor.stringFlavor);
+            assertEquals(actualInformation, expectedInformation);
+        } catch (IOException | UnsupportedFlavorException e) {
+            throw new AssertionError("Execution of command should not fail.", e);
+        }
+    }
+
+    @Test
+    public void execute_copyInvalidIndex_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        CopyCommand copyCommand = new CopyCommand(outOfBoundIndex);
+
+        assertCommandFailure(copyCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -1,19 +1,10 @@
 package seedu.address.logic.commands;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
-import java.awt.Toolkit;
-import java.awt.datatransfer.Clipboard;
-import java.awt.datatransfer.DataFlavor;
-import java.awt.datatransfer.StringSelection;
-import java.awt.datatransfer.UnsupportedFlavorException;
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.Messages;
@@ -21,36 +12,17 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.person.Person;
 
 public class CopyCommandTest {
 
-    private final Clipboard clipboard = Toolkit.getDefaultToolkit().getSystemClipboard();
     private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private final Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
-    private final StringSelection emptyString = new StringSelection("");
-
-    @BeforeEach
-    public void setUp() {
-        // Clear clipboard contents
-        clipboard.setContents(emptyString, null);
-    }
 
     @Test
-    public void execute_copyValidIndex_success() throws IOException, UnsupportedFlavorException {
-        Person personToCopy = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+    public void execute_copyValidIndex_success() {
         CopyCommand copyCommand = new CopyCommand(INDEX_FIRST_PERSON);
 
         assertCommandSuccess(copyCommand, model, CopyCommand.MESSAGE_COPY_SUCCESS, expectedModel);
-
-        // Check contents of clipboard
-        try {
-            String expectedInformation = copyCommand.getInformation(personToCopy);
-            String actualInformation = (String) clipboard.getData(DataFlavor.stringFlavor);
-            assertEquals(actualInformation, expectedInformation);
-        } catch (IOException | UnsupportedFlavorException e) {
-            throw new AssertionError("Execution of command should not fail.", e);
-        }
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CopyCommandTest.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -1,0 +1,24 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.logic.commands.CopyCommand;
+
+public class CopyCommandParserTest {
+
+    private final CopyCommandParser parser = new CopyCommandParser();
+
+    @Test
+    public void parse_validArgs_returnCopyCommand() {
+        assertParseSuccess(parser, "1", new CopyCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "x", String.format(MESSAGE_INVALID_COMMAND_FORMAT, CopyCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/CopyCommandParserTest.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.logic.commands.CopyCommand;
 
 public class CopyCommandParserTest {


### PR DESCRIPTION
`CopyCommand` is a `Command` that represents the `Copy` command which users can use in the UI.

`CopyCommandParser` is a `Parser` that is responsible for the parsing of arguments when the `Copy` command is used.

Users can quickly copy information of a person to their clipboard using the command without manually selecting it in the UI.

Closes #40 