### PR TITLE
Revert to using `kramdown` to fix GitHub pages TOC

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,7 +6,7 @@ header_pages:
   - DeveloperGuide.md
   - AboutUs.md
 
-markdown: GFM
+markdown: kramdown
 
 repository: "AY2223S2-CS2103T-W10-3/tp"
 github_icon: "images/github-icon.png"


### PR DESCRIPTION
Revert to using `kramdown` as the [Markdown processor for GitHub Pages](https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/setting-a-markdown-processor-for-your-github-pages-site-using-jekyll).

Current website using `GFM`: https://ay2223s2-cs2103t-w10-3.github.io/tp/UserGuide.html
Preview website using `kramdown`: https://rexcyrio.github.io/tp/UserGuide.html

Do help to check that the links in the table of contents work for you too.

Closes #56 

