### PR TITLE
Fix command history bug

### DIFF
--- a/src/main/java/seedu/address/storage/CommandHistoryArrayList.java
+++ b/src/main/java/seedu/address/storage/CommandHistoryArrayList.java
@@ -18,7 +18,7 @@ public class CommandHistoryArrayList {
     public CommandHistoryArrayList(ArrayList<String> arrayList) {
         this.arrayList = arrayList;
         temporaryUserInput = "";
-        currentPosition = 0;
+        currentPosition = arrayList.size();
     }
 
     public String getPreviousUserInput(String currentUserInput) {

--- a/src/test/java/seedu/address/storage/CommandHistoryTest.java
+++ b/src/test/java/seedu/address/storage/CommandHistoryTest.java
@@ -2,6 +2,7 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.File;
@@ -40,7 +41,30 @@ public class CommandHistoryTest {
     }
 
     @Test
-    public void commitUserInputAndUpdateCommandHistoryFile_success() {
+    public void navigateCommandHistory_fileAlreadyExists_success() {
+        Path filePath = TEST_DATA_FOLDER.resolve("command_history.txt");
+        File file = new File(filePath.toString());
+
+        assertTrue(file.exists());
+        CommandHistory commandHistory = new CommandHistory(filePath);
+        assertTrue(file.exists());
+
+        String originalString = "original";
+        assertEquals(commandHistory.getPreviousUserInput(originalString), "list 3");
+        assertEquals(commandHistory.getPreviousUserInput("dummy aaa"), "clear");
+        assertEquals(commandHistory.getPreviousUserInput("dummy bbb"), "list 2");
+        assertEquals(commandHistory.getPreviousUserInput("dummy ccc"), "list 1");
+        assertNull(commandHistory.getPreviousUserInput("dummy dddd"));
+
+        assertEquals(commandHistory.getNextUserInput(), "list 2");
+        assertEquals(commandHistory.getNextUserInput(), "clear");
+        assertEquals(commandHistory.getNextUserInput(), "list 3");
+        assertEquals(commandHistory.getNextUserInput(), originalString);
+        assertNull(commandHistory.getNextUserInput());
+    }
+
+    @Test
+    public void commitUserInputAndUpdateCommandHistoryFile_fileDoesNotExist_success() {
         Path testFilePath = TEST_DATA_FOLDER.resolve("testFile.txt");
         File testFile = new File(testFilePath.toString());
 
@@ -62,5 +86,39 @@ public class CommandHistoryTest {
 
         // clean up
         assertTrue(testFile.delete());
+    }
+
+    @Test
+    public void commitUserInputAndUpdateCommandHistoryFile_fileAlreadyExists_success() {
+        Path filePath = TEST_DATA_FOLDER.resolve("command_history.txt");
+        Path filePathCopy = TEST_DATA_FOLDER.resolve("command_history_copy.txt");
+
+        try {
+            Files.copy(filePath, filePathCopy);
+        } catch (IOException e) {
+            // hopefully this doesn't happen during testing
+            throw new RuntimeException(e);
+        }
+
+        File fileCopy = new File(filePathCopy.toString());
+
+        assertTrue(fileCopy.exists());
+        CommandHistory commandHistory = new CommandHistory(filePathCopy);
+        assertTrue(fileCopy.exists());
+
+        commandHistory.commitUserInput("first");
+        commandHistory.commitUserInput("second");
+        commandHistory.commitUserInput("third");
+
+        try {
+            String fileCopyContents = Files.readString(filePathCopy);
+            assertEquals("list 1\nlist 2\nclear\nlist 3\nfirst\nsecond\nthird", fileCopyContents);
+        } catch (IOException e) {
+            // hopefully this doesn't happen during testing
+            throw new RuntimeException(e);
+        }
+
+        // clean up
+        assertTrue(fileCopy.delete());
     }
 }


### PR DESCRIPTION
- Add test cases to test for said bug

-----

Bug fix: upon loading a `command_history.txt` file, the pointer was set as `0` when it should have pointed to the end of the command history instead (i.e., the pointer should have pointed at `arrayList.size()`)